### PR TITLE
subscriberのgoroutineをgraceful shutdownする

### DIFF
--- a/go/cmd/server/main.go
+++ b/go/cmd/server/main.go
@@ -3,8 +3,6 @@ package main
 import (
 	"context"
 
-	_ "net/http/pprof"
-
 	"github.com/ispec-inc/monorepo/go/runner/server"
 )
 

--- a/go/cmd/server/main.go
+++ b/go/cmd/server/main.go
@@ -3,10 +3,13 @@ package main
 import (
 	"context"
 
+	_ "net/http/pprof"
+
 	"github.com/ispec-inc/monorepo/go/runner/server"
 )
 
 func main() {
+
 	server, sclnup, err := server.New()
 	if err != nil {
 		panic(err)

--- a/go/go.mod
+++ b/go/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/golang/mock v1.5.0
 	github.com/gomodule/redigo v1.7.1-0.20190724094224-574c33c3df38
 	github.com/google/uuid v1.2.0
+	github.com/graphql-go/graphql v0.7.9
+	github.com/graphql-go/handler v0.2.3
 	github.com/k0kubun/pp v2.4.0+incompatible
 	github.com/lib/pq v1.10.0 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go/go.sum
+++ b/go/go.sum
@@ -160,6 +160,10 @@ github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/graphql-go/graphql v0.7.9 h1:5Va/Rt4l5g3YjwDnid3vFfn43faaQBq7rMcIZ0VnV34=
+github.com/graphql-go/graphql v0.7.9/go.mod h1:k6yrAYQaSP59DC5UVxbgxESlmVyojThKdORUqGDGmrI=
+github.com/graphql-go/handler v0.2.3 h1:CANh8WPnl5M9uA25c2GBhPqJhE53Fg0Iue/fRNla71E=
+github.com/graphql-go/handler v0.2.3/go.mod h1:leLF6RpV5uZMN1CdImAxuiayrYYhOk33bZciaUGaXeU=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=

--- a/go/pkg/msgbs/server.go
+++ b/go/pkg/msgbs/server.go
@@ -2,28 +2,42 @@ package msgbs
 
 import (
 	"context"
+	"sync"
 )
 
-type SubscribeServer []Subscriber
+type SubscribeServer struct {
+	subscribers []Subscriber
+	done        chan interface{}
+	wg          *sync.WaitGroup
+}
 
 func NewSubscribeServer() SubscribeServer {
-	return SubscribeServer{}
+	return SubscribeServer{
+		done: make(chan interface{}),
+		wg:   &sync.WaitGroup{},
+	}
 }
 
 func (s SubscribeServer) Serve(ctx context.Context) {
-	for _, subsc := range s {
-		subsc.Do(ctx)
+	for _, subsc := range s.subscribers {
+		subsc.Do(ctx, s.done, s.wg)
 	}
 }
 
 func (s *SubscribeServer) Mount(subsc Subscriber) {
-	*s = append(*s, subsc)
+	s.subscribers = append(s.subscribers, subsc)
 }
 
-func (s SubscribeServer) Shutdown() {
-	for _, subsc := range s {
+func (s SubscribeServer) Shutdown(ctx context.Context) {
+	for _, subsc := range s.subscribers {
 		for evnt := range subsc.Router {
 			subsc.MessageBus.Unsubscribe(evnt)
 		}
 	}
+
+	go func() {
+		s.done <- true
+	}()
+
+	s.wg.Wait()
 }

--- a/go/pkg/msgbs/subscriber.go
+++ b/go/pkg/msgbs/subscriber.go
@@ -3,6 +3,7 @@ package msgbs
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/ispec-inc/monorepo/go/pkg/applog"
@@ -34,12 +35,18 @@ func (s Subscriber) Mount(rtr Router) {
 	}
 }
 
-func (s Subscriber) Do(ctx context.Context) {
+func (s Subscriber) Do(
+	ctx context.Context,
+	done chan interface{},
+	wg *sync.WaitGroup,
+) {
 	for evnt, sfuncs := range s.Router {
 		s.MessageBus.Subscribe(evnt)
 		for _, sfunc := range sfuncs {
-			go func(sfunc SubscribeFunc) {
+			wg.Add(1)
+			go func(ctx context.Context, sfunc SubscribeFunc) {
 				for {
+
 					switch v := s.MessageBus.Receive().(type) {
 					case redis.Message:
 						err := sfunc(ctx, v)
@@ -51,8 +58,14 @@ func (s Subscriber) Do(ctx context.Context) {
 					case error:
 						s.AppLog.Error(ctx, v)
 					}
+
+					select {
+					case <-done:
+						wg.Done()
+						return
+					}
 				}
-			}(sfunc)
+			}(ctx, sfunc)
 		}
 	}
 }

--- a/go/pkg/msgbs/subscriber.go
+++ b/go/pkg/msgbs/subscriber.go
@@ -63,6 +63,7 @@ func (s Subscriber) Do(
 					case <-done:
 						wg.Done()
 						return
+					default:
 					}
 				}
 			}(ctx, sfunc)

--- a/go/runner/router/http.go
+++ b/go/runner/router/http.go
@@ -41,13 +41,16 @@ func NewHTTP() (*http.Server, func() error, error) {
 
 	clnup := func() error {
 		var errs error
-		for _, clnup := range clnups {
-			errs = multierr.Append(errs, clnup())
+		for _, c := range clnups {
+			if c != nil {
+				errs = multierr.Append(errs, c())
+			}
 		}
 		return errs
 	}
 
 	port := fmt.Sprintf(":%d", PORT)
+
 	srv := &http.Server{Addr: port, Handler: r}
 	return srv, clnup, nil
 

--- a/go/runner/server/server.go
+++ b/go/runner/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"log"
 	"net/http"
 	"os"
 	"os/signal"
@@ -45,7 +44,6 @@ func (s Server) Run(ctx context.Context) {
 	g.Go(func() error {
 		err := s.HTTPServer.ListenAndServe()
 		if err != nil && err != http.ErrServerClosed {
-			log.Println(err)
 			return err
 		}
 

--- a/go/runner/server/server.go
+++ b/go/runner/server/server.go
@@ -2,11 +2,11 @@ package server
 
 import (
 	"context"
+	"log"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/ispec-inc/monorepo/go/pkg/msgbs"
 	"github.com/ispec-inc/monorepo/go/runner/router"
@@ -45,6 +45,7 @@ func (s Server) Run(ctx context.Context) {
 	g.Go(func() error {
 		err := s.HTTPServer.ListenAndServe()
 		if err != nil && err != http.ErrServerClosed {
+			log.Println(err)
 			return err
 		}
 
@@ -69,14 +70,11 @@ func (s Server) Run(ctx context.Context) {
 		break
 	}
 
-	ctx, tcancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer tcancel()
+	s.HTTPServer.Shutdown(ctx)
+	s.SubscribeServer.Shutdown(ctx)
 
 	err := g.Wait()
 	if err != nil {
 		os.Exit(2)
 	}
-
-	s.HTTPServer.Shutdown(ctx)
-	s.SubscribeServer.Shutdown()
 }

--- a/go/svc/article/pkg/registry/logger.go
+++ b/go/svc/article/pkg/registry/logger.go
@@ -32,6 +32,7 @@ func NewLogger() (Logger, func() error, error) {
 		err = serr
 	default:
 		lgr = stdlog.New()
+		clenaup = func() error { return nil }
 	}
 
 	return Logger{lgr}, clenaup, err

--- a/go/svc/media/pkg/registry/logger.go
+++ b/go/svc/media/pkg/registry/logger.go
@@ -32,6 +32,7 @@ func NewLogger() (Logger, func() error, error) {
 		err = serr
 	default:
 		lgr = stdlog.New()
+		clenaup = func() error { return nil }
 	}
 
 	return Logger{lgr}, clenaup, err

--- a/go/svc/notification/pkg/registry/logger.go
+++ b/go/svc/notification/pkg/registry/logger.go
@@ -32,6 +32,7 @@ func NewLogger() (Logger, func() error, error) {
 		err = serr
 	default:
 		lgr = stdlog.New()
+		clenaup = func() error { return nil }
 	}
 
 	return Logger{lgr}, clenaup, err


### PR DESCRIPTION
## 該当イシュー
なし

## 外部仕様の変更点
- 特になし

## 内部仕様の変更点
- serverのerrgroupのタイミングが良くなかったので、プロセスが終了しなかった。
- タイミングを後に持っていった上で、subscriberの処理をgraceful shutdownできるようにした

設計方針は[こちら](https://www.notion.so/ispec/Go-Subscriber-Graceful-Shutdown-c665743ca02e41bd8e2d08f421f2fbd1)

## 動作を保証するためのテストケースの詳細
- 手元で挙動を確認
