### PR TITLE
VuexStoreをAPIへのリクエスト/レスポンスに関するキャッシュ置き場として利用するためのモジュール実装

### DIFF
--- a/typescript/apps/admin/core/sample/gateway.ts
+++ b/typescript/apps/admin/core/sample/gateway.ts
@@ -1,0 +1,22 @@
+import { cacheSampleModule } from "~/store/cache/sample"
+import { ApiWithCacheEnabled } from "~/utils/api-with-cache-enabled"
+
+export class SampleGatewayImpl {
+  private readonly api: ApiWithCacheEnabled<{ title: string, author: string, content: string }, { id: number }>
+
+  constructor() {
+    const endpoint = (payload: { id: number }): Promise<{ title: string, author: string, content: string }> => {
+      console.log('payload', payload)
+      return Promise.resolve({
+        title: `article ${payload.id}`,
+        author: 'sample author',
+        content: 'sample'
+      })
+    }
+    this.api = new ApiWithCacheEnabled(endpoint, cacheSampleModule)
+  }
+
+  fetchById(id: number): Promise<{ title: string, author: string, content: string }> {
+    return this.api.callApi({ id })
+  }
+}

--- a/typescript/apps/admin/pages/index.vue
+++ b/typescript/apps/admin/pages/index.vue
@@ -10,15 +10,34 @@
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator'
 import articleModule from '@/store/article'
+import { SampleGatewayImpl } from '~/core/sample/gateway'
 
 @Component({})
 export default class TopPage extends Vue {
+  gateway = new SampleGatewayImpl()
+
   created() {
     articleModule.fetch()
+
+    this.callApi(1)
+
+    setTimeout(() => {
+      this.callApi(1)
+    }, 1000)
+
+    setTimeout(() => {
+      this.callApi(2)
+    }, 2000)
   }
 
   get articleList() {
     return articleModule.articles
+  }
+
+  callApi(id: number) {
+    this.gateway.fetchById(id).then((res) => {
+      console.log('response', res)
+    })
   }
 }
 </script>

--- a/typescript/apps/admin/store/cache/sample.ts
+++ b/typescript/apps/admin/store/cache/sample.ts
@@ -1,0 +1,40 @@
+import {
+  Module,
+  VuexModule,
+  Action,
+  Mutation,
+  getModule,
+} from 'vuex-module-decorators'
+import { store } from '@/store'
+import { ApiResponseCache, CacheModule } from '~/utils/api-with-cache-enabled'
+
+type Payload = { id: number }
+type Response = { title: string, author: string, content: string }
+type Cache = ApiResponseCache<Response, Payload>
+
+@Module({ name: 'cache_sample', dynamic: true, store, namespaced: true })
+export class CacheSampleModule extends VuexModule implements CacheModule<Response, Payload> {
+  private _cachedData: Cache | null = null
+
+  @Mutation
+  private SET_CACHED_DATA(payload: Cache | null): void {
+    this._cachedData = payload
+  }
+
+  @Action({rawError: true})
+  cache(payload: Cache) {
+    this.SET_CACHED_DATA(payload)
+  }
+
+  @Action({rawError: true})
+  clear() {
+    this.SET_CACHED_DATA(null)
+  }
+
+  get cachedData(): Cache | null {
+    return this._cachedData
+  }
+}
+
+const cacheSampleModule = getModule(CacheSampleModule)
+export { cacheSampleModule }

--- a/typescript/apps/admin/utils/api-with-cache-enabled.ts
+++ b/typescript/apps/admin/utils/api-with-cache-enabled.ts
@@ -1,0 +1,46 @@
+import { compareObject } from "./compare-object"
+
+export type ApiResponseCache<T, U extends Object> = {
+  response: T
+  payload: U
+}
+
+export interface CacheModule<T, U extends Object> {
+  cache(payload: ApiResponseCache<T, U>): void
+  clear(): void
+  readonly cachedData: ApiResponseCache<T, U> | null
+}
+
+export class ApiWithCacheEnabled<T, U extends Object> {
+  private readonly endpoint: (payload: U) => Promise<T>
+  private readonly cahceModule: CacheModule<T, U>
+
+  constructor(endpoint: (payload: U) => Promise<T>, cahceModule: CacheModule<T, U>) {
+    this.cahceModule = cahceModule
+    this.endpoint = endpoint
+  }
+
+  callApi(payload: U): Promise<T> {
+    // キャッシュがある場合はペイロードを比較し、同一である場合はキャッシュされたレスポンスでresolveする
+    if (this.cachedData && compareObject(payload, this.cachedData.payload)) {
+      return Promise.resolve(this.cachedData.response)
+    }
+
+    return new Promise((resolve, reject) => {
+      this.endpoint(payload)
+        .then((response) => {
+          this.cahceModule.cache({ payload, response })
+          resolve(response)
+        })
+        .catch(reject)
+    })
+  }
+
+  clearCache(): void {
+    this.cahceModule.clear()
+  }
+
+  private get cachedData(): ApiResponseCache<T, U> | null {
+    return this.cahceModule.cachedData
+  }
+}

--- a/typescript/apps/admin/utils/compare-object.ts
+++ b/typescript/apps/admin/utils/compare-object.ts
@@ -1,0 +1,18 @@
+function objectSort(obj: Object): Object {
+  // ソートする
+  const sorted = Object.entries(obj).sort();
+
+  // valueを調べ、objectならsorted entriesに変換する
+  for(const i in sorted){
+      const val = sorted[i][1];
+      if(typeof val === "object"){
+          sorted[i][1] = objectSort(val);
+      }
+  }
+
+  return sorted;
+}
+
+export function compareObject(a: Object, b: Object): boolean {
+  return JSON.stringify(objectSort(a)) === JSON.stringify(objectSort(b))
+}


### PR DESCRIPTION
## 該当イシュー
なし

## 外部仕様の変更点
(フロントエンド の人に説明する必要がある場合)

## 内部仕様の変更点
- VuexStoreを用いて特定のAPIへリクエスト/レスポンスデータをキャッシュするモジュールの実装(`ApiWithCacheEnabled`)
  - サンプルのStoreとGateway実装

## 動作を保証するためのテストケースの詳細
- rspecのテストケース
- エンドツーエンドテストケース

## ApiWithCacheEnabledについて
- インスタンス化時の引数
  - リクエストに利用する値を受け取り、Promiseを返す関数
  - `interface CacheModule`に基づいて実装されたVuexModule
- `callApi(payload: U): Promise<T>`
  - 引数のpayloadと、キャッシュされているpayloadを比較し一致する場合は、キャッシュ済みのレスポンスを返す
  - そうでない場合は、インスタンス化する際に渡したAPIを呼び出す関数を実行し、payloadとレスポンスをキャッシュする
- `clearCache(): void`
  - キャッシュを削除する
  - キャッシュを用いず、確実にAPIを呼び出したい場合などに、先にこの関数を呼び出す
- frontend software designにおける、Gatewayレイヤーで利用することを想定している
- 実装例は`core/sample/gateway.ts`で確認できる

## 備考
- ルートのページで、`ApiWithCacheEnabled`を利用して実装したGatewayの挙動テストができる
- Gatewayを呼び出す側では以下の画像1枚目のように実装されており、
  1. payload: { id: 1 }
  2. payload: { id: 1 }
  3. payload: { id: 2 }
  
  の順でGatewayの関数を呼び出している
- また、実際にAPIを呼び出す想定の部分ではpayloadを出力、レスポンスを受け取る部分ではレスポンス内容を出力するように実装してある
- 上記の前提と画像2枚目から、2回目のリクエストでは同じpayloadを送信していることになるので、その部分ではpayloadが出力されずキャッシュされているresponseのみが出力されていることが確認できる

![スクリーンショット 2021-09-27 17 05 08](https://user-images.githubusercontent.com/38396299/134868711-936b42e3-753e-46d1-95d9-c8ee985fcef4.png)

![スクリーンショット 2021-09-27 16 53 32](https://user-images.githubusercontent.com/38396299/134868629-348bbed6-313c-42e7-a6e6-e4ebcf4e0080.png)