### PR TITLE
Serviceレイヤーをページごとにキャッシュできるように

### DIFF
--- a/typescript/apps/admin/core/03-service/index.ts
+++ b/typescript/apps/admin/core/03-service/index.ts
@@ -1,0 +1,16 @@
+import { AuthGatewayImpl } from "../01-gateway/auth";
+import { AuthRepositoryImpl } from "../02-repository/auth";
+import { LoginPageService } from "./login";
+
+export namespace ServiceIndex {
+  export const constructors = {
+    login: (): LoginPageService => {
+      return new LoginPageService(new AuthRepositoryImpl(new AuthGatewayImpl()))
+    }
+  }
+
+  export type AsObject = { [P in keyof typeof constructors]: ReturnType<typeof constructors[P]> }
+
+  type FilterByService<T extends keyof AsObject, U extends AsObject[keyof AsObject]> = T extends any ? AsObject[T] extends U ? T : never : never
+  export type FilteredKey<T extends AsObject[keyof AsObject]> = FilterByService<keyof AsObject, T>
+}

--- a/typescript/apps/admin/pages/login.vue
+++ b/typescript/apps/admin/pages/login.vue
@@ -28,10 +28,9 @@
 import { Component, mixins } from 'nuxt-property-decorator'
 import { LoginForm } from '~/form-providers/login-form'
 import LoginPageForm from '~/components/pages/login-page-form.vue'
-import { LoginPageService } from '~/core/03-service/login'
-import { AuthRepositoryImpl } from '~/core/02-repository/auth'
-import { AuthGatewayImpl } from '~/core/01-gateway/auth'
 import UseSubscription from '~/components/mixins/use-subscription'
+import { pageServicesModule } from '~/store/page-services'
+import { LoginPageService } from '~/core/03-service/login'
 
 @Component({
   layout: 'centered',
@@ -40,9 +39,7 @@ import UseSubscription from '~/components/mixins/use-subscription'
   },
 })
 export default class LoginPage extends mixins(UseSubscription) {
-  readonly service = new LoginPageService(
-    new AuthRepositoryImpl(new AuthGatewayImpl())
-  )
+  readonly service: LoginPageService = pageServicesModule.getService('login')
 
   form = LoginForm.provideModule()
 

--- a/typescript/apps/admin/store/page-services.ts
+++ b/typescript/apps/admin/store/page-services.ts
@@ -1,0 +1,34 @@
+import {
+  Module,
+  VuexModule,
+  Action,
+  Mutation,
+  getModule,
+} from 'vuex-module-decorators'
+import { store } from '@/store'
+import { ServiceIndex } from '~/core/03-service'
+
+@Module({ name: 'page-services', dynamic: true, store, namespaced: true })
+export class PageServicesModule extends VuexModule {
+  private cache: Partial<ServiceIndex.AsObject> = {}
+
+  @Mutation
+  CACHE_SERVICE<T extends keyof ServiceIndex.AsObject>(payload: { key: T, service: ServiceIndex.AsObject[T] }): void {
+    this.cache[payload.key] = payload.service
+  }
+
+  @Action({rawError: true})
+  getService<T extends ServiceIndex.AsObject[keyof ServiceIndex.AsObject]>(key: ServiceIndex.FilteredKey<T>): T {
+    const cachedService = this.cache[key]
+    if (cachedService) {
+      return cachedService as T
+    }
+
+    const service = ServiceIndex.constructors[key]()
+    this.CACHE_SERVICE({ key: key as keyof ServiceIndex.AsObject, service })
+    return service as T
+  }
+}
+
+const pageServicesModule = getModule(PageServicesModule)
+export { pageServicesModule }

--- a/typescript/libs/fast-form/dist/index.d.ts
+++ b/typescript/libs/fast-form/dist/index.d.ts
@@ -2,7 +2,7 @@ import Resource from "./resource";
 import { FormModule } from './form';
 import { SeparatedFormModule } from './separated-form';
 import { FormTextInputModule } from './form-input/text';
-import { FormPasswordInputModule } from './form-input/password';
+import { FormPasswordInputModule } from "./form-input/password";
 import { FormNumberInputModule } from './form-input/number';
 import { FormDateInputModule } from './form-input/date';
 import { FormSelectInputModule } from './form-input/select';

--- a/typescript/libs/fast-form/dist/index.js
+++ b/typescript/libs/fast-form/dist/index.js
@@ -2,7 +2,7 @@ import Resource from "./resource";
 import { FormModule } from './form';
 import { SeparatedFormModule } from './separated-form';
 import { FormTextInputModule } from './form-input/text';
-import { FormPasswordInputModule } from './form-input/password';
+import { FormPasswordInputModule } from "./form-input/password";
 import { FormNumberInputModule } from './form-input/number';
 import { FormDateInputModule } from './form-input/date';
 import { FormSelectInputModule } from './form-input/select';


### PR DESCRIPTION
## 該当イシュー
なし

## 外部仕様の変更点
(フロントエンド の人に説明する必要がある場合)

## 内部仕様の変更点
- Serviceは各ページでインスタンス化していたが、それだとページにアクセスするたびにインスタンス化していることになるので、インスタンス化とそのインスタンスの保存をStoreで行わせ、ViewではStoreのActionを経由してServiceを取得するように

## 動作を保証するためのテストケースの詳細
- rspecのテストケース
- エンドツーエンドテストケース

## Serviceの追加、利用方法
1. `core/03-service/index.ts`の`ServiceIndex.constructors`へ適当な名前のkeyとともに、該当Serviceをインスタンス化する関数を定義する
2. Serviceを利用するViewで、`pageServicesModule.getService(/* 1で設定したkey名 */)`