### PR TITLE
[typescript/admin] component用mixinを追加

### DIFF
--- a/typescript/apps/admin/components/mixins/beforeunload-guard.ts
+++ b/typescript/apps/admin/components/mixins/beforeunload-guard.ts
@@ -1,0 +1,36 @@
+import { Vue, Component } from 'nuxt-property-decorator'
+import { Route } from 'vue-router'
+
+@Component
+export default class BeforeUnloadGuardMixin extends Vue {
+  // 表示するメッセージ
+  protected beforeUnloadGuardMessage = '入力した内容が失われる可能性があります。よろしいですか？';
+  protected disableBlockUnload = false;
+
+  created() {
+    if (process.client) {
+      window.addEventListener("beforeunload", this.checkWindow);
+    }
+  }
+
+  beforeDestroy() {
+    window.removeEventListener("beforeunload", this.checkWindow);
+  }
+
+  protected checkWindow(event: BeforeUnloadEvent) {
+    if (this.disableBlockUnload) {
+      return
+    }
+    event.preventDefault();
+    event.returnValue = this.beforeUnloadGuardMessage;
+  }
+
+  beforeRouteLeave(_to: Route, _from: Route, next: Function) {
+    if (this.disableBlockUnload) {
+      next()
+      return
+    }
+    const answer = window.confirm(this.beforeUnloadGuardMessage);
+    next(answer);
+  }
+}

--- a/typescript/apps/admin/components/mixins/use-subscription.ts
+++ b/typescript/apps/admin/components/mixins/use-subscription.ts
@@ -1,0 +1,11 @@
+import { Vue, Component } from 'vue-property-decorator'
+import { Subscription } from 'rxjs'
+
+@Component
+export default class UseSubscription extends Vue {
+  protected readonly subscription = new Subscription()
+
+  beforeDestroy() {
+    this.subscription.unsubscribe()
+  }
+}

--- a/typescript/apps/admin/nuxt.config.js
+++ b/typescript/apps/admin/nuxt.config.js
@@ -44,6 +44,7 @@ export default {
     { src: '~plugins/axios.ts' },
     { src: '~plugins/axios-accessor.ts' },
     { src: '~plugins/vee-validate.ts' },
+    { src: '~plugins/hooks.ts' },
   ],
   /*
    ** Auto import components

--- a/typescript/apps/admin/pages/sample/form.vue
+++ b/typescript/apps/admin/pages/sample/form.vue
@@ -15,16 +15,17 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component } from 'vue-property-decorator'
+import { Component, mixins } from 'nuxt-property-decorator'
 import { SampleForm } from '~/form-providers/sample-form'
 import ResourceForm from '~/components/common/resource-form.vue'
+import BeforeUnloadGuardMixin from '~/components/mixins/beforeunload-guard'
 
 @Component({
   components: {
     ResourceForm,
   },
 })
-export default class SampleFormPage extends Vue {
+export default class SampleFormPage extends mixins(BeforeUnloadGuardMixin) {
   form = SampleForm.provideModule()
 
   submit(value: SampleForm.AsObject) {

--- a/typescript/apps/admin/plugins/hooks.ts
+++ b/typescript/apps/admin/plugins/hooks.ts
@@ -1,0 +1,5 @@
+import { Component } from 'nuxt-property-decorator'
+
+Component.registerHooks([
+  'beforeRouteLeave',
+])


### PR DESCRIPTION
## 該当イシュー
なし

## 外部仕様の変更点
(フロントエンド の人に説明する必要がある場合)

## 内部仕様の変更点
- ページ離脱防止処理を実装できる`BeforeUnloadGuardMixin`の実装
- Subscriptionのインスタンス化、beforeDestroyフックでそのunsubscribeを行う`UseSubscription`の実装
- これらは、各Pageコンポーネントで、`export default class ~~~Page extends Vue`とするところを`export default class ~~~Page extends mixins(BeforeUnloadGuardMixin)`などとすることで利用ができる

## 動作を保証するためのテストケースの詳細
- rspecのテストケース
- エンドツーエンドテストケース
