### PR TITLE
[WIP] core周りのtemplateの追加

### DIFF
--- a/typescript/apps/admin/_templates/core/gateway/index.ejs.t
+++ b/typescript/apps/admin/_templates/core/gateway/index.ejs.t
@@ -1,0 +1,33 @@
+---
+to: core/01_gateways/<%= name %>/index.ts
+---
+<%
+	gatewayName = h.inflection.capitalize(name) + 'Gateway'
+	interfaceName = `I${gatewayName}`
+%>import { Apollo } from 'apollo-angular'
+import { Observable } from 'rxjs'
+export interface <%= gatewayName %> {
+	fetch(): Observable<TYPE_NAME>
+}
+
+export class <%= gatewayName %>Impl implements <%= interfaceName %> {
+	apollo: Apollo
+
+  constructor(apollo: Apollo) {
+		this.apollo = apollo
+	}
+
+  get response(): <%= gatewayName %>.AsResponse {
+    return this._response
+  }
+
+	fetch(): Observable<> {
+		return this.apollo.use(ENDPOINT_NAME)
+			.watchQuery<>({
+				query: MODEL_NAME.schema(),
+			})
+			.valueChanges
+	}
+
+}
+

--- a/typescript/apps/admin/_templates/core/gateway/test.ejs.t
+++ b/typescript/apps/admin/_templates/core/gateway/test.ejs.t
@@ -1,0 +1,11 @@
+---
+to: core/01_gateways/<%= name %>/test.spec.ts
+---
+<%
+	gatewayName = h.inflection.capitalize(name) + 'Gateway'
+%>import { <%= gatewayName %> } from '.'
+
+describe('core/01-gateways/<%= name %>', () => {
+
+})
+

--- a/typescript/apps/admin/_templates/core/model/index.ejs.t
+++ b/typescript/apps/admin/_templates/core/model/index.ejs.t
@@ -1,0 +1,41 @@
+---
+to: core/00_models/<%= name %>/index.ts
+---
+<% 
+	modelName = h.inflection.capitalize(name) + 'Model' 
+	interfaceName = `I${modelName}` 
+%>import { gql } from 'apollo-angular'
+import { DocumentNode } from '@apollo/client/link/core/types'
+
+export interface <%= interfaceName %> {
+}
+
+export class <%= modelName %> implements <%= interfaceName %> {
+
+  private readonly _response: <%= modelName %>.AsResponse
+
+  constructor(response: <%= modelName %>.AsResponse) {
+    this._response = response
+	}
+
+  get response(): <%= modelName %>.AsResponse {
+    return this._response
+  }
+
+  static schema(): DocumentNode {
+    return gql`
+      query queryName {
+      }
+    `
+}
+
+export namespace <%= modelName %> {
+	export type Sample = {
+		sample: string
+	}
+	export type AsResponse = {
+		sample: Sample
+	}
+}
+
+

--- a/typescript/apps/admin/_templates/core/model/test.ejs.t
+++ b/typescript/apps/admin/_templates/core/model/test.ejs.t
@@ -1,0 +1,11 @@
+---
+to: core/00_models/<%= name %>/test.spec.ts
+---
+<%
+	modelName = h.inflection.capitalize(name) + 'Model'
+%>import { <%= modelName %> } from '.'
+
+describe('core/00_models/<%= name %>', () => {
+
+})
+

--- a/typescript/apps/admin/_templates/core/repository/index.ejs.t
+++ b/typescript/apps/admin/_templates/core/repository/index.ejs.t
@@ -1,0 +1,11 @@
+---
+to: core/02_repositories/<%= name %>/test.spec.ts
+---
+<%
+	repositoryName = h.inflection.capitalize(name) + 'Repository'
+%>import { <%= repositoryName %> } from '.'
+
+describe('core/02-repositories/<%= name %>', () => {
+
+})
+

--- a/typescript/apps/admin/_templates/core/repository/test.ejs.t
+++ b/typescript/apps/admin/_templates/core/repository/test.ejs.t
@@ -1,0 +1,11 @@
+---
+to: core/02_repositories/<%= name %>/test.spec.ts
+---
+<%
+	repositoryName = h.inflection.capitalize(name) + 'Repository'
+%>import { <%= repositoryName %> } from '.'
+
+describe('core/02_repositories/<%= name %>', () => {
+
+})
+

--- a/typescript/apps/admin/_templates/core/service/index.ejs.t
+++ b/typescript/apps/admin/_templates/core/service/index.ejs.t
@@ -1,0 +1,21 @@
+---
+to: core/03_services/<%= name %>/index.ts
+---
+<%
+	serviceName = h.inflection.capitalize(name) + 'Service'
+	interfaceName = `I${serviceName}`
+%>import { Observable } from 'rxjs'
+import { map } from 'rxjs/pperators'
+
+export interface <%= interfaceName %> {
+	fetch(): Observable<>
+}
+
+export class <%= serviceName %>Impl implements <%= interfaceName %> {
+
+  constructor() {
+	
+	}
+
+}
+

--- a/typescript/apps/admin/_templates/core/service/test.ejs.t
+++ b/typescript/apps/admin/_templates/core/service/test.ejs.t
@@ -1,0 +1,11 @@
+---
+to: core/03_services/<%= name %>/test.spec.ts
+---
+<%
+	serviceName = h.inflection.capitalize(name) + 'Service'
+%>import { <%= serviceName %> } from '.'
+
+describe('core/03_services/<%= name %>', () => {
+
+})
+


### PR DESCRIPTION
## 該当Notion
https://www.notion.so/ispec/core-code-219d67dca0b144fcadeffcfc12f68b77

## 外部仕様の変更点
core周りのテンプレートを追加しました。

以下のコマンドで実行することができます。
```
# sampleという名前のgatewayの雛形を作りたい時
$ yarn hygen core gateway:index --name sample

# sampleという名前のgatewayのテストを作りたい時
$ yarn hygen core gateway:test --name sample
```

## 内部仕様の変更点
N/A

## 動作を保証するためのテストケースの詳細
N/A